### PR TITLE
Defer copying slug

### DIFF
--- a/commands/fork.js
+++ b/commands/fork.js
@@ -76,15 +76,15 @@ function* fork (context, heroku) {
   yield cli.action('Setting buildpacks', apps.setBuildpacks(oldApp, newApp));
 
   if (stopping) { return; }
-  yield apps.copySlug(newApp, slug);
-
-  yield wait(2000); // TODO remove this after api #4022
-
-  if (stopping) { return; }
   yield addons.copyAddons(oldApp, newApp, context.flags['skip-pg']);
 
   if (stopping) { return; }
   yield addons.copyConfigVars(oldApp, newApp);
+
+  if (stopping) { return; }
+  yield apps.copySlug(newApp, slug);
+
+  yield wait(2000); // TODO remove this after api #4022
 
   console.log(`Fork complete. View it at ${cli.color.cyan(newApp.web_url)}`);
 }

--- a/commands/fork.js
+++ b/commands/fork.js
@@ -79,6 +79,7 @@ function* fork (context, heroku) {
   yield apps.copySlug(newApp, slug);
 
   yield wait(2000); // TODO remove this after api #4022
+
   if (stopping) { return; }
   yield addons.copyAddons(oldApp, newApp, context.flags['skip-pg']);
 


### PR DESCRIPTION
As Cedar-10 has been deprecated, you can't copy the slug because the slug is associated with a stack and copying implies migrating to that stack.

Copying add-ons and configuration before the slug will still fail the fork but at least you have copied everything but the slug and can then just push the source to perform a new build yielding a new slug.
