### PR TITLE
Fix assumption that _URL is the only config_var

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -67,9 +67,16 @@ Postgres.prototype = {
     };
   },
 
+  databaseName: function (db) {
+    return db.config_vars.map(function (config_var) {
+      let match = config_var.match(/(.*)_URL/);
+      return match && match[1];
+    }).find((name) => name);
+  },
+
   startTransfer: function (fromConfig, fromDB, toConfig, toDB) {
-    let fromName  = fromDB.config_vars[0].match(/(.*)_URL/)[1];
-    let toName    = toDB.config_vars[0].match(/(.*)_URL/)[1];
+    let fromName  = this.databaseName(fromDB);
+    let toName    = this.databaseName(toDB);
     let fromURL   = fromConfig[`${fromName}_URL`];
     let toURL     = toConfig[`${toName}_URL`];
     return function (db) {


### PR DESCRIPTION
@dickeyxxx could you review?  this is to fix postgres database transfers for private spaces where _URL is not the only config var